### PR TITLE
Page Size Builder

### DIFF
--- a/src/Form/PageSizeBuilder.php
+++ b/src/Form/PageSizeBuilder.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WeDevelop\UXTable\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class PageSizeBuilder
+{
+    public const DEFAULT_PAGE_SIZES = [10, 20, 50, 100];
+    public const DEFAULT_PAGE_SIZE = 50;
+    public const DEFAULT_FIELD_NAME = 'pageSize';
+
+    public function __construct(
+        private readonly FormBuilderInterface $builder,
+        private readonly string $fieldName = self::DEFAULT_FIELD_NAME,
+    ) {}
+
+    public static function getCalculatedPageSize(FormInterface $form, string $fieldName = self::DEFAULT_FIELD_NAME): int
+    {
+        if (!is_a($form->getConfig()->getType()->getInnerType(), UXTableFormType::class, false)) {
+            throw new \RuntimeException(sprintf('Form type must extend from "%s" to calculate page size.', self::class));
+        }
+
+        $choiceField = $form->get($fieldName);
+        if (!is_a($choiceField->getConfig()->getType()->getInnerType(), ChoiceType::class, false)) {
+            throw new \RuntimeException(sprintf('Form field "%s" must be of type "%s" to calculate page size.', $fieldName, ChoiceType::class));
+        }
+
+        // From the query string if it's a valid choice, then the form options
+        // if it's a valid choice, otherwise the first choice available.
+        // If there are no valid options to choose from default to the default
+        // page size defined in this class.
+        return (int)($choiceField->getNormData()
+            ?? ($choiceField->getConfig()->getData() ?: null)
+            ?? ($choiceField->getConfig()->getEmptyData() ?: null)
+            ?? array_key_first($choiceField->getConfig()->getOption('choices'))
+            ?? throw new \RuntimeException(sprintf('There must be at least one page size configured for field "%s".', $fieldName)));
+    }
+
+    public static function addFormOptions(OptionsResolver $resolver): OptionsResolver
+    {
+        $resolver->define('pageSize')->allowedTypes('int')->default(PageSizeBuilder::DEFAULT_PAGE_SIZE);
+        $resolver->define('pageSizes')->allowedTypes('int[]')->default(PageSizeBuilder::DEFAULT_PAGE_SIZES);
+
+        return $resolver;
+    }
+
+    public function build(
+        FormBuilderInterface $builder,
+        array $additionalOptions = [],
+    ): FormBuilderInterface {
+        // Default raw value coming from query string (expects to be string).
+        $default = (string)$this->getDefaultPageSize();
+        $builder->add($this->fieldName, ChoiceType::class, array_merge($additionalOptions, [
+            'required' => false,
+            'placeholder' => false,
+            'choices' => $this->getChoices(),
+            'data' => $default,
+            'empty_data' => $default,
+        ]));
+
+        $this->addEventListener($builder);
+
+        return $builder;
+    }
+
+    /** @return array<int, int> */
+    private function getChoices(): array
+    {
+        $choices = array_values($this->validatePageSizes(
+            $this->builder->getOptions()['pageSizes'] ?? null,
+        ) ?? self::DEFAULT_PAGE_SIZES);
+
+        return array_combine($choices, $choices);
+    }
+
+    private function getDefaultPageSize(): int
+    {
+        $choices = $this->getChoices();
+        $defaults = [$this->builder->getOptions()['pageSize'] ?? null, self::DEFAULT_PAGE_SIZE, array_key_first($choices)];
+        foreach ($defaults as $default) {
+            if (array_key_exists($default, $choices)) {
+                return $default;
+            }
+        }
+
+        // Unreachable statement (see getChoices/validatePageSizes). Keep PHPStan happy.
+        return 0;
+    }
+
+    private function addEventListener(FormBuilderInterface $builder): void
+    {
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event): void {
+            $data = $event->getData();
+            $pageSize = $data[$this->fieldName] ?? null;
+            if (null !== $pageSize && '' !== $pageSize && !array_key_exists((int) $pageSize, $this->getChoices())) {
+                $data[$this->fieldName] = $this->getDefaultPageSize();
+                $event->setData($data);
+            }
+        });
+    }
+
+    /**
+     * @return array<int>|null
+     */
+    private function validatePageSizes(mixed $choices): ?array
+    {
+        return is_array($choices) && count($choices) > 0 && array_reduce(
+            $choices,
+            fn($carry, $item) => $carry && is_int($item),
+            true,
+        ) ? $choices : null;
+    }
+}

--- a/src/Form/UXTableFormType.php
+++ b/src/Form/UXTableFormType.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace WeDevelop\UXTable\Form;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\SearchType;
@@ -45,6 +44,8 @@ abstract class UXTableFormType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver)
     {
+        PageSizeBuilder::addFormOptions($resolver);
+
         $resolver->setDefaults([
             'csrf_protection' => false,
             'sort_whitelist' => [],
@@ -69,16 +70,9 @@ abstract class UXTableFormType extends AbstractType
 
     protected function addPageSize(FormBuilderInterface $builder): self
     {
-        $builder->add('pageSize', ChoiceType::class, [
-            'required' => false,
+        $pageSizeBuilder = new PageSizeBuilder($builder);
+        $pageSizeBuilder->build($builder, [
             'attr' => ['data-action' => $this->stimulusSearch('change')],
-            'placeholder' => false,
-            'choices' => [
-                10 => 10,
-                20 => 20,
-                50 => 50,
-                100 => 100,
-            ]
         ]);
 
         return $this;


### PR DESCRIPTION
Add page size field to existing form, complete with sensible default fallbacks and event listeners to ignore invalid values.

### Added Form Option `pageSizes`

The size of pages in the dropdown can be configured with the `pageSizes` option, which defaults to: 10, 20, 50, 100.

```php
$form = $this->createForm(UXTableFormType::class, ['pageSizes' => [
    13, 19, 29, 53,
]]);
```

### Added Form Option `pageSize`

The default page size, if none is selected via the query string, can be configured with the `pageSize` option, which defaults to 50.

```php
$this->createForm(UXTableFormType::class, ['pageSize' => 100]);
```

If the `pageSize` is not a valid choice from the list of `pageSizes`, then it will ignore the configured value and use a default value.

```php
// The `pageSizes` are not configured and default to 10, 20, 50, and 100.
// The `pageSize` value of 99 is not in that list of page sizes so defaults to
// the UXTableFormType default, 50.
$this->createForm(UXTableFormType::class, ['pageSize' => 99]);

// The `pageSize` value of 99 is not in the list of configured page sizes, and
// neither is the UXTableFormType default of 50 so it defaults to the first
// value in the list of page sizes, which is 15.
$this->createForm(UXTableFormType::class, ['pageSize' => 99, 'pageSizes' => [
    15, 30, 45, 60
]]);
```

### Added Static Method `getCalculatedPageSize()`

Fetch the calculated page size from the form, regardless of submitted value in the query string, form configuration, or lack thereof.

```php
class MyFormType extends UXTableFormType {}

$form = $this->createForm(MyFormType::class);
$pageSize = PageSizeBuilder::getCalculatedPageSize($form);

$paginator->paginate($entityQuery, $page, $pageSize);
```

### Added Form Event Listener

Any value submitted on the query string that is not a valid choice will result in the value being forced to the calculated default page size to prevent errors from being presented to the end-user.
