### PR TITLE
Bug Fix: Option to Disable Default Doctrine ORM Provider

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -15,6 +15,10 @@ class Configuration implements ConfigurationInterface
 
         $treeBuilder->getRootNode()
             ->children()
+                ->booleanNode('use_default_orm_provider')
+                    ->info('Disable this if you do not have Doctrine ORM installed (eg, using Mongo).')
+                    ->defaultTrue()
+                ->end()
                 ->arrayNode('opener')
                 ->addDefaultsIfNotSet()
                     ->children()

--- a/src/DependencyInjection/WeDevelopUXTableExtension.php
+++ b/src/DependencyInjection/WeDevelopUXTableExtension.php
@@ -64,10 +64,11 @@ final class WeDevelopUXTableExtension extends Extension implements PrependExtens
         $container->registerForAutoconfiguration(DataProviderInterface::class)
             ->addTag(DataProviderInterface::class);
 
-        $container->register(DoctrineORMProvider::class)
-            ->setAutowired(true)
-            ->setAutoconfigured(true)
-        ;
+        if ($config['use_default_orm_provider']) {
+            $container->register(DoctrineORMProvider::class)
+                ->setAutowired(true)
+                ->setAutoconfigured(true);
+        }
     }
 
     public function prepend(ContainerBuilder $container)


### PR DESCRIPTION
`EntityManagerInterface` cannot be autowire on projects that use Mongo instead of ORM.