### PR TITLE
🐛 Bugfix: Correctly Pass Configured pageSize/s options to PageSizeBuilder

### DIFF
--- a/src/Form/PageSizeBuilder.php
+++ b/src/Form/PageSizeBuilder.php
@@ -17,8 +17,9 @@ final class PageSizeBuilder
     public const DEFAULT_PAGE_SIZE = 50;
     public const DEFAULT_FIELD_NAME = 'pageSize';
 
+    /** @param array{pageSize?: int, pageSizes?: array<int>} $options */
     public function __construct(
-        private readonly FormBuilderInterface $builder,
+        private readonly array $options = [],
         private readonly string $fieldName = self::DEFAULT_FIELD_NAME,
     ) {}
 
@@ -71,7 +72,7 @@ final class PageSizeBuilder
     private function getChoices(): array
     {
         $choices = array_values($this->validatePageSizes(
-            $this->builder->getOptions()['pageSizes'] ?? null,
+            $this->options['pageSizes'] ?? null,
         ) ?? self::DEFAULT_PAGE_SIZES);
 
         return array_combine($choices, $choices);
@@ -80,7 +81,7 @@ final class PageSizeBuilder
     private function getDefaultPageSize(): int
     {
         $choices = $this->getChoices();
-        $defaults = [$this->builder->getOptions()['pageSize'] ?? null, self::DEFAULT_PAGE_SIZE, array_key_first($choices)];
+        $defaults = [$this->options['pageSize'] ?? null, self::DEFAULT_PAGE_SIZE, array_key_first($choices)];
         foreach ($defaults as $default) {
             if (array_key_exists($default, $choices)) {
                 return $default;

--- a/src/Table/AbstractTable.php
+++ b/src/Table/AbstractTable.php
@@ -113,11 +113,12 @@ abstract class AbstractTable implements TableInterface
         ];
     }
 
+    /** @param array{pageSize?: int, pageSizes?: array<int>} $options */
     private function buildForm(array $options): FormInterface
     {
         $builder = $this->buildBaseForm();
 
-        $this->addPageSize($builder);
+        $this->addPageSize($builder, $options);
 
         $filterFormBuilder = $builder->create('filter', FormType::class, ['label' => false]);
 
@@ -143,9 +144,10 @@ abstract class AbstractTable implements TableInterface
         return $builder;
     }
 
-    private function addPageSize(FormBuilderInterface $builder): void
+    /** @param array{pageSize?: int, pageSizes?: array<int>} $options */
+    private function addPageSize(FormBuilderInterface $builder, array $options): void
     {
-        $pageSizeBuilder = new PageSizeBuilder($builder);
+        $pageSizeBuilder = new PageSizeBuilder($options);
         $pageSizeBuilder->build($builder, [
             'attr' => ['data-action' => $this->stimulusSearch('change')],
         ]);
@@ -181,7 +183,7 @@ abstract class AbstractTable implements TableInterface
         ;
 
         $dataProvider->configureOptions($resolver);
-
+        PageSizeBuilder::addFormOptions($resolver);
         $this->configureOptions($resolver);
 
         return $resolver->resolve($options);


### PR DESCRIPTION
Configured option values for `pageSize`/`pageSizes` were never passed to the `PageSizeBuilder` so it was always using the default values.

Previous implementation incorrectly assumed that the base form builder's `OptionsResolver` was the same as the AbstractTable's `OptionsResolver`.

fixes #14