### PR TITLE
Feature/symfony 8 compatibility

### DIFF
--- a/src/DependencyInjection/WeDevelopUXTableExtension.php
+++ b/src/DependencyInjection/WeDevelopUXTableExtension.php
@@ -71,7 +71,7 @@ final class WeDevelopUXTableExtension extends Extension implements PrependExtens
         }
     }
 
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         if ($this->isAssetMapperAvailable($container)) {
             $container->prependExtensionConfig('framework', [

--- a/src/Table/AbstractTable.php
+++ b/src/Table/AbstractTable.php
@@ -6,7 +6,7 @@ namespace WeDevelop\UXTable\Table;
 
 use Knp\Component\Pager\Pagination\PaginationInterface;
 use Knp\Component\Pager\PaginatorInterface;
-use Symfony\Component\DependencyInjection\Attribute\TaggedLocator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -28,7 +28,7 @@ abstract class AbstractTable implements TableInterface
     private ?PaginationInterface $pagination = null;
 
     public function __construct(
-        #[TaggedLocator(DataProviderInterface::class)]
+        #[AutowireLocator(DataProviderInterface::class)]
         private readonly ServiceLocator $dataProviders,
         private readonly FormFactoryInterface $formFactory,
     ) {


### PR DESCRIPTION
The bundle currently cannot run on Symfony 8.x.  The prepend method in WeDevelopUXTableExtension is not compatible with method prepend in symfony 8, and TaggedLocator is deprecied and not present in symfony 8. See https://github.com/symfony/symfony/pull/60845

## Environment
- wedevelopnl/ux-table: v0.4.2
- Symfony: 8.1.x
- PHP: 8.4

## Blocking points identified

1. `TaggedLocator` attribute was removed in Symfony 8 
   (deprecated since 7.1 in favor of `AutowireLocator`).
   Used in `src/Table/AbstractTable.php`:

2. **`PrependExtensionInterface::prepend()` now declares a native
`: void` return type** in Symfony 8, so
`WeDevelopUXTableExtension::prepend()` must add it.
