### PR TITLE
Setup phpunit and first test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 # Because this library will never be the root package, don't commit Composer's lock file.
 /composer.lock
+.phpunit.cache/

--- a/composer.json
+++ b/composer.json
@@ -30,5 +30,8 @@
     "suggest": {
         "symfony/webpack-encore-bundle": "to use the Stimulus assets included in this bundle",
         "symfony/ux-turbo": "*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.5"
     }
 }

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="UX Table Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/Security/OpenerSigner.php
+++ b/src/Security/OpenerSigner.php
@@ -9,7 +9,7 @@ final class OpenerSigner
     {
     }
 
-    public function sign(string $openerUrl)
+    public function sign(string $openerUrl): string
     {
         return hash_hmac('sha256', $openerUrl, $this->secret);
     }

--- a/tests/Security/OpenerSignerTest.php
+++ b/tests/Security/OpenerSignerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WeDevelop\UXTable\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+use WeDevelop\UXTable\Security\OpenerSigner;
+
+class OpenerSignerTest extends TestCase
+{
+    private const SECRET = "secret";
+    private const TEST_URI = '/uri/path';
+
+    public function testSign(): void
+    {
+        $openerSigner = new OpenerSigner(self::SECRET);
+        $expectedSignature = hash_hmac('sha256', self::TEST_URI, self::SECRET);
+        $this->assertSame($expectedSignature ,$openerSigner->sign(self::TEST_URI), "opener signature mismatch");
+    }
+
+    public function testVerify(): void
+    {
+        $openerSigner = new OpenerSigner(self::SECRET);
+        $expectedSignature = hash_hmac('sha256', self::TEST_URI, self::SECRET);
+
+        $this->assertTrue($openerSigner->verify(self::TEST_URI,  $expectedSignature), "signatures should match");
+        $this->assertFalse($openerSigner->verify(self::TEST_URI,  "wrong signature"), "signatures should mismatch");
+
+    }
+}


### PR DESCRIPTION
As discussed in [[QUESTION] PR about test coverage](https://github.com/wedevelopnl/ux-table/issues/19) i have added :

- phpunit 10.5 in composer as dev dependency.
- a basic phpunit.dist.xml
-  a test for OpenerSigner. It' s simple to test , maybe even useless. It just serves to ensure that unit test are working.
- I also added an explicit return type for sign method in OpenerSigner.
